### PR TITLE
fix: validation and typechecks in TF post processing and OTSL to HTML conversion function

### DIFF
--- a/docling_ibm_models/tableformer/models/table04_rs/bbox_decoder_rs.py
+++ b/docling_ibm_models/tableformer/models/table04_rs/bbox_decoder_rs.py
@@ -157,7 +157,12 @@ class BBoxDecoder(nn.Module):
             predictions_classes.append(self._class_embed(h))
         if len(predictions_bboxes) > 0:
             predictions_bboxes = torch.stack([x[0] for x in predictions_bboxes])
+        else:
+            predictions_bboxes = torch.empty(0)
+
         if len(predictions_classes) > 0:
             predictions_classes = torch.stack([x[0] for x in predictions_classes])
+        else:
+            predictions_classes = torch.empty(0)
 
         return predictions_classes, predictions_bboxes

--- a/docling_ibm_models/tableformer/models/table04_rs/tablemodel04_rs.py
+++ b/docling_ibm_models/tableformer/models/table04_rs/tablemodel04_rs.py
@@ -281,8 +281,12 @@ class TableModel04_rs(BaseModel, nn.Module):
         else:
             outputs_class, outputs_coord = None, None
 
-        outputs_class.to(self._device)
-        outputs_coord.to(self._device)
+        if outputs_class is not None:
+            if torch.is_tensor(outputs_class):
+                outputs_class.to(self._device)
+        if outputs_coord is not None:
+            if torch.is_tensor(outputs_coord):
+                outputs_coord.to(self._device)
 
         ########################################################################################
         # Merge First and Last predicted BBOX for each span, according to bboxes_to_merge

--- a/docling_ibm_models/tableformer/models/table04_rs/tablemodel04_rs.py
+++ b/docling_ibm_models/tableformer/models/table04_rs/tablemodel04_rs.py
@@ -281,12 +281,8 @@ class TableModel04_rs(BaseModel, nn.Module):
         else:
             outputs_class, outputs_coord = None, None
 
-        if outputs_class is not None:
-            if torch.is_tensor(outputs_class):
-                outputs_class.to(self._device)
-        if outputs_coord is not None:
-            if torch.is_tensor(outputs_coord):
-                outputs_coord.to(self._device)
+        outputs_class.to(self._device)
+        outputs_coord.to(self._device)
 
         ########################################################################################
         # Merge First and Last predicted BBOX for each span, according to bboxes_to_merge

--- a/docling_ibm_models/tableformer/otsl.py
+++ b/docling_ibm_models/tableformer/otsl.py
@@ -123,6 +123,9 @@ def otsl_check_right(rs_split, x, y):
 
 
 def otsl_to_html(rs_list, logdebug):
+    if len(rs_list) == 0:
+        return []
+
     if rs_list[0] not in ["fcel", "ched", "rhed", "srow", "ecel"]:
         # Most likely already HTML...
         return rs_list


### PR DESCRIPTION
- Improved TF bbox post-processing step that corrected bboxes overlap, now should produce more correct bboxes
- Bbox overlap correction step made optional, as an extra parameter in multi_table_predict
- Corrected otsl_to_html to be fault tolerant to empty rs_list