### PR TITLE
fix: Add in common.py the function read_config() 

### DIFF
--- a/docling_ibm_models/tableformer/common.py
+++ b/docling_ibm_models/tableformer/common.py
@@ -48,6 +48,16 @@ def validate_config(config):
     return True
 
 
+def read_config(config_filename):
+    with open(config_filename, "r") as fd:
+        config = json.load(fd)
+
+    # Validate the config file
+    validate_config(config)
+
+    return config
+
+
 def safe_get_parameter(input_dict, index_path, default=None, required=False):
     r"""
     Safe get parameter from a nested dictionary.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,7 +2,11 @@
 # Copyright IBM Corp. 2024 - 2024
 # SPDX-License-Identifier: MIT
 #
+import json
+import tempfile
+
 import docling_ibm_models.tableformer.common as c
+
 
 test_config_a = {
     "base_dir": "./tests/test_data/",
@@ -70,3 +74,16 @@ def test_config_validation():
                 assert val, "Valid configuration didn't pass the validation test"
         except AssertionError:
             assert i == 2, "Configuration validation error"
+
+def test_read_config():
+    r"""
+    Testing the read_config() function
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as fp:
+        # Write a tmp file
+        json.dump(test_config_a, fp)
+        fp.close()
+
+        # Read the tmp file and extract the config
+        config = c.read_config(fp.name)
+        assert isinstance(config, dict)


### PR DESCRIPTION
This commit adds the missing function `read_config()` in `common.py` and extends the unit tests to cover it.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

