### PR TITLE
fix: compare .label in predict_merges skip loop, not element object

### DIFF
--- a/docling_ibm_models/reading_order/reading_order_rb.py
+++ b/docling_ibm_models/reading_order/reading_order_rb.py
@@ -183,7 +183,7 @@ class ReadingOrderPredictor:
             if elem.label in [DocItemLabel.TEXT]:
 
                 ind_p1 = ind + 1
-                while ind_p1 < len(sorted_elements) and sorted_elements[ind_p1] in [
+                while ind_p1 < len(sorted_elements) and sorted_elements[ind_p1].label in [
                     DocItemLabel.PAGE_HEADER,
                     DocItemLabel.PAGE_FOOTER,
                     DocItemLabel.TABLE,

--- a/docling_ibm_models/reading_order/reading_order_rb.py
+++ b/docling_ibm_models/reading_order/reading_order_rb.py
@@ -183,7 +183,9 @@ class ReadingOrderPredictor:
             if elem.label in [DocItemLabel.TEXT]:
 
                 ind_p1 = ind + 1
-                while ind_p1 < len(sorted_elements) and sorted_elements[ind_p1].label in [
+                while ind_p1 < len(sorted_elements) and sorted_elements[
+                    ind_p1
+                ].label in [
                     DocItemLabel.PAGE_HEADER,
                     DocItemLabel.PAGE_FOOTER,
                     DocItemLabel.TABLE,
@@ -681,7 +683,7 @@ class ReadingOrderPredictor:
         """
 
         def _remove_overlapping_indexes(
-            mapping: Dict[int, List[int]]
+            mapping: Dict[int, List[int]],
         ) -> Dict[int, List[int]]:
             used = set()
             result = {}

--- a/docling_ibm_models/tableformer/data_management/tf_predictor.py
+++ b/docling_ibm_models/tableformer/data_management/tf_predictor.py
@@ -433,7 +433,7 @@ class TFPredictor:
         # initialize the dimensions of the image to be resized and
         # grab the image size
         dim = None
-        (h, w) = image.shape[:2]
+        h, w = image.shape[:2]
         sf = 1.0
         # if both the width and height are None, then return the
         # original image


### PR DESCRIPTION
## Bug

In `predict_merges`, the `while` loop is intended to skip over interrupting elements (page headers, footers, tables, pictures, captions, footnotes) between two TEXT elements before deciding whether to merge them.

The loop condition compared the `PageElement` object itself against a list of `DocItemLabel` enum values:

```python
while ind_p1 < len(sorted_elements) and sorted_elements[ind_p1] in [
    DocItemLabel.PAGE_HEADER,
    DocItemLabel.PAGE_FOOTER,
    ...
]:
```

Since a `PageElement` instance is never equal to a `DocItemLabel` enum value, this comparison always evaluates to `False` — the skip loop never advances and interrupting elements are never skipped.

## Fix

Compare the element's `.label` attribute instead:

```python
while ind_p1 < len(sorted_elements) and sorted_elements[ind_p1].label in [
    DocItemLabel.PAGE_HEADER,
    ...
]:
```