### PR TITLE
fix: extend predict_merges patterns for soft hyphen and Unicode letters

### DIFF
--- a/docling_ibm_models/reading_order/reading_order_rb.py
+++ b/docling_ibm_models/reading_order/reading_order_rb.py
@@ -203,7 +203,9 @@ class ReadingOrderPredictor:
                 ):
 
                     m1 = re.fullmatch(r".+([a-z,\-\u00AD])(\s*)", elem.text)
-                    m2 = re.fullmatch(r"(\s*[a-zA-Z\u00C0-\u024F])(.+)", sorted_elements[ind_p1].text)
+                    m2 = re.fullmatch(
+                        r"(\s*[a-zA-Z\u00C0-\u024F])(.+)", sorted_elements[ind_p1].text
+                    )
 
                     if m1 and m2:
                         merges[elem.cid] = [sorted_elements[ind_p1].cid]
@@ -681,7 +683,7 @@ class ReadingOrderPredictor:
         """
 
         def _remove_overlapping_indexes(
-            mapping: Dict[int, List[int]]
+            mapping: Dict[int, List[int]],
         ) -> Dict[int, List[int]]:
             used = set()
             result = {}

--- a/docling_ibm_models/reading_order/reading_order_rb.py
+++ b/docling_ibm_models/reading_order/reading_order_rb.py
@@ -202,8 +202,8 @@ class ReadingOrderPredictor:
                     )
                 ):
 
-                    m1 = re.fullmatch(r".+([a-z,\-])(\s*)", elem.text)
-                    m2 = re.fullmatch(r"(\s*[a-z])(.+)", sorted_elements[ind_p1].text)
+                    m1 = re.fullmatch(r".+([a-z,\-\u00AD])(\s*)", elem.text)
+                    m2 = re.fullmatch(r"(\s*[a-zA-Z\u00C0-\u024F])(.+)", sorted_elements[ind_p1].text)
 
                     if m1 and m2:
                         merges[elem.cid] = [sorted_elements[ind_p1].cid]

--- a/docling_ibm_models/tableformer/data_management/tf_predictor.py
+++ b/docling_ibm_models/tableformer/data_management/tf_predictor.py
@@ -433,7 +433,7 @@ class TFPredictor:
         # initialize the dimensions of the image to be resized and
         # grab the image size
         dim = None
-        (h, w) = image.shape[:2]
+        h, w = image.shape[:2]
         sf = 1.0
         # if both the width and height are None, then return the
         # original image


### PR DESCRIPTION
## Problem

The merge-continuation heuristic in `predict_merges` uses two patterns:
- **m1**: checks that the current element ends with a continuation character `[a-z,\-]`
- **m2**: checks that the next element starts with a lowercase letter `[a-z]`

Two gaps prevent valid merges:

### 1. Soft hyphen (U+00AD) not handled

Typeset PDFs (books, journals) use U+00AD (SOFT HYPHEN) for optional line-break hyphenation. The character is invisible in rendered text but present in the PDF text layer. A line ending with U+00AD is unambiguously a mid-word line break, but the original pattern `[a-z,\-]` does not match it — so the two halves of the hyphenated word end up as separate paragraphs in the output.

### 2. m2 rejects uppercase continuation lines

m2 only accepted `[a-z]`, so continuation lines starting with an uppercase letter were never merged. This affects:
- German nouns (always uppercase)
- Lines after hard line-breaks in typeset text where the next word happens to be capitalised
- Any mid-sentence line-break where m1 clearly indicates no sentence end (no `.`, `!`, `?`)

Since m1 already ensures the previous line did **not** end with sentence-ending punctuation, allowing uppercase in m2 is safe.

## Fix

```python
# before
m1 = re.fullmatch(r".+([a-z,\-])(\s*)", elem.text)
m2 = re.fullmatch(r"(\s*[a-z])(.+)", sorted_elements[ind_p1].text)

# after
m1 = re.fullmatch(r".+([a-z,\-\u00AD])(\s*)", elem.text)
m2 = re.fullmatch(r"(\s*[a-zA-Z\u00C0-\u024F])(.+)", sorted_elements[ind_p1].text)
```