### PR TITLE
fix: chain merge continuations instead of stopping after one pair

### DIFF
--- a/docling_ibm_models/reading_order/reading_order_rb.py
+++ b/docling_ibm_models/reading_order/reading_order_rb.py
@@ -206,7 +206,7 @@ class ReadingOrderPredictor:
                         ind_p1 < len(sorted_elements)
                         and sorted_elements[ind_p1].label == elem.label
                         and (
-                            elem.page_no != sorted_elements[ind_p1].label
+                            elem.page_no != sorted_elements[ind_p1].page_no
                             or elem.is_strictly_left_of(sorted_elements[ind_p1])
                         )
                     ):

--- a/docling_ibm_models/reading_order/reading_order_rb.py
+++ b/docling_ibm_models/reading_order/reading_order_rb.py
@@ -174,6 +174,15 @@ class ReadingOrderPredictor:
 
         merges: Dict[int, List[int]] = {}
 
+        skip_labels = [
+            DocItemLabel.PAGE_HEADER,
+            DocItemLabel.PAGE_FOOTER,
+            DocItemLabel.TABLE,
+            DocItemLabel.PICTURE,
+            DocItemLabel.CAPTION,
+            DocItemLabel.FOOTNOTE,
+        ]
+
         curr_ind = -1
         for ind, elem in enumerate(sorted_elements):
 
@@ -182,32 +191,36 @@ class ReadingOrderPredictor:
 
             if elem.label in [DocItemLabel.TEXT]:
 
-                ind_p1 = ind + 1
-                while ind_p1 < len(sorted_elements) and sorted_elements[ind_p1] in [
-                    DocItemLabel.PAGE_HEADER,
-                    DocItemLabel.PAGE_FOOTER,
-                    DocItemLabel.TABLE,
-                    DocItemLabel.PICTURE,
-                    DocItemLabel.CAPTION,
-                    DocItemLabel.FOOTNOTE,
-                ]:
-                    ind_p1 += 1
+                merge_list: List[int] = []
+                check_ind = ind
 
-                if (
-                    ind_p1 < len(sorted_elements)
-                    and sorted_elements[ind_p1].label == elem.label
-                    and (
-                        elem.page_no != sorted_elements[ind_p1].label
-                        or elem.is_strictly_left_of(sorted_elements[ind_p1])
-                    )
-                ):
+                while True:
+                    ind_p1 = check_ind + 1
+                    while ind_p1 < len(sorted_elements) and sorted_elements[ind_p1].label in skip_labels:
+                        ind_p1 += 1
 
-                    m1 = re.fullmatch(r".+([a-z,\-])(\s*)", elem.text)
-                    m2 = re.fullmatch(r"(\s*[a-z])(.+)", sorted_elements[ind_p1].text)
+                    if (
+                        ind_p1 < len(sorted_elements)
+                        and sorted_elements[ind_p1].label == elem.label
+                        and (
+                            elem.page_no != sorted_elements[ind_p1].label
+                            or elem.is_strictly_left_of(sorted_elements[ind_p1])
+                        )
+                    ):
+                        m1 = re.fullmatch(r".+([a-z,\-])(\s*)", sorted_elements[check_ind].text)
+                        m2 = re.fullmatch(r"(\s*[a-z])(.+)", sorted_elements[ind_p1].text)
 
-                    if m1 and m2:
-                        merges[elem.cid] = [sorted_elements[ind_p1].cid]
-                        curr_ind = ind_p1
+                        if m1 and m2:
+                            merge_list.append(sorted_elements[ind_p1].cid)
+                            curr_ind = ind_p1
+                            check_ind = ind_p1
+                        else:
+                            break
+                    else:
+                        break
+
+                if merge_list:
+                    merges[elem.cid] = merge_list
 
         return merges
 

--- a/docling_ibm_models/reading_order/reading_order_rb.py
+++ b/docling_ibm_models/reading_order/reading_order_rb.py
@@ -196,7 +196,10 @@ class ReadingOrderPredictor:
 
                 while True:
                     ind_p1 = check_ind + 1
-                    while ind_p1 < len(sorted_elements) and sorted_elements[ind_p1].label in skip_labels:
+                    while (
+                        ind_p1 < len(sorted_elements)
+                        and sorted_elements[ind_p1].label in skip_labels
+                    ):
                         ind_p1 += 1
 
                     if (
@@ -207,8 +210,12 @@ class ReadingOrderPredictor:
                             or elem.is_strictly_left_of(sorted_elements[ind_p1])
                         )
                     ):
-                        m1 = re.fullmatch(r".+([a-z,\-])(\s*)", sorted_elements[check_ind].text)
-                        m2 = re.fullmatch(r"(\s*[a-z])(.+)", sorted_elements[ind_p1].text)
+                        m1 = re.fullmatch(
+                            r".+([a-z,\-])(\s*)", sorted_elements[check_ind].text
+                        )
+                        m2 = re.fullmatch(
+                            r"(\s*[a-z])(.+)", sorted_elements[ind_p1].text
+                        )
 
                         if m1 and m2:
                             merge_list.append(sorted_elements[ind_p1].cid)
@@ -694,7 +701,7 @@ class ReadingOrderPredictor:
         """
 
         def _remove_overlapping_indexes(
-            mapping: Dict[int, List[int]]
+            mapping: Dict[int, List[int]],
         ) -> Dict[int, List[int]]:
             used = set()
             result = {}

--- a/docling_ibm_models/tableformer/data_management/tf_predictor.py
+++ b/docling_ibm_models/tableformer/data_management/tf_predictor.py
@@ -433,7 +433,7 @@ class TFPredictor:
         # initialize the dimensions of the image to be resized and
         # grab the image size
         dim = None
-        (h, w) = image.shape[:2]
+        h, w = image.shape[:2]
         sf = 1.0
         # if both the width and height are None, then return the
         # original image


### PR DESCRIPTION
## Problem

`predict_merges` merges at most **one** successor per TEXT element. After recording `merges[A] = [B]` it sets `curr_ind = B` and moves on, so C is processed as a fresh element rather than being appended to A's merge list.

If A continues into B and B continues into C by the same criteria, all three belong to the same paragraph. The current code produces two short paragraphs (A+B and C+D) instead of one.

This becomes visible with PDFs that have many small orphan clusters — for example scanned pages with a native text layer, where each line of text is its own cluster. The pairwise limit leaves every other line as a separate paragraph, causing unnatural blank lines throughout the output.

## Fix

Replace the single `if`-block with a `while` loop that keeps extending the merge chain from the current tail (`check_ind`) as long as the continuation condition holds:

```python
merge_list: List[int] = []
check_ind = ind

while True:
    # find next non-skippable element from check_ind
    ...
    m1 = re.fullmatch(r".+([a-z,\-])(\s*)", sorted_elements[check_ind].text)
    m2 = re.fullmatch(r"(\s*[a-z])(.+)", sorted_elements[ind_p1].text)
    if m1 and m2:
        merge_list.append(sorted_elements[ind_p1].cid)
        curr_ind = ind_p1
        check_ind = ind_p1
    else:
        break

if merge_list:
    merges[elem.cid] = merge_list
```

The existing `_readingorder_elements_to_docling_doc` already iterates over the full merge list per element, so no changes are needed there.

Also fixes the skip-loop element-vs-label comparison (`sorted_elements[ind_p1].label in skip_labels` instead of `sorted_elements[ind_p1] in [...]` which always evaluated to False — also submitted separately as #153).