### PR TITLE
fix: Load TableFormer model with torch.load(..., weights_only=True)

### DIFF
--- a/docling_ibm_models/tableformer/models/common/base_model.py
+++ b/docling_ibm_models/tableformer/models/common/base_model.py
@@ -254,7 +254,9 @@ class BaseModel(ABC):
                     "Loading model checkpoint file: {}".format(checkpoint_file)
                 )
                 saved_model = torch.load(
-                    checkpoint_file, map_location=self._device, weights_only=False
+                    checkpoint_file,
+                    map_location=self._device,
+                    weights_only=True,
                 )
                 return saved_model, checkpoint_file
             except RuntimeError:


### PR DESCRIPTION
Ensure that the TableFormer model loads with `torch.load(..., weights_only=True)`

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

