### PR TITLE
fix: skip AutoImageProcessor registration when config_class breaks on transformers 5.13

### DIFF
--- a/docling_ibm_models/code_formula_model/models/sam_opt_image_processor.py
+++ b/docling_ibm_models/code_formula_model/models/sam_opt_image_processor.py
@@ -23,7 +23,13 @@ class SamOptImageProcessor(BaseImageProcessor):
         return image
 
 
-AutoImageProcessor.register(
-    config_class="SamOptImageProcessor",
-    slow_image_processor_class=SamOptImageProcessor,
-)
+try:
+    AutoImageProcessor.register(
+        config_class="SamOptImageProcessor",
+        slow_image_processor_class=SamOptImageProcessor,
+    )
+except AttributeError:
+    # transformers >=5.13 reads config_class.__module__ unconditionally, which breaks
+    # for our string config_class. SamOptImageProcessor is always loaded directly via
+    # from_pretrained, not through AutoImageProcessor, so skipping is safe.
+    pass


### PR DESCRIPTION
With transformers 5.13, importing `CodeFormulaPredictor` breaks with `AttributeError: 'str' object has no attribute '__module__'` inside `AutoImageProcessor.register()`. sam_opt_image_processor.py registers itself with `config_class="SamOptImageProcessor"`, a plain string rather than a real `PreTrainedConfig` subclass. That worked by accident through 4.42-5.12 because the internal `_LazyAutoMapping.register` only read `key.__name__`, behind a `hasattr` guard. 5.13 added an unconditional `key.__module__` read ahead of that guard, and strings don't have `__module__`.

`CodeFormulaPredictor` always loads `SamOptImageProcessor` directly via `from_pretrained`, never through `AutoImageProcessor`, so the registration isn't required for anything in this repo. This wraps the `register()` call in a try/except AttributeError and skips it on failure, which keeps the import working across the whole 4.42-6.0 range this package supports. Verified directly against 4.42.0, 5.8.1 and 5.13.0. Registration still succeeds normally on the first two, and only the 5.13 path falls through to the except.

No new tests, following the precedent from #164 (the last transformers-version-compat fix in this area), which also shipped without one. Full local suite and pre-commit (black, isort, mypy) pass.

**Issue resolved by this Pull Request:**
Resolves #167

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
