### PR TITLE
feat(pdf): recognize compound and hierarchical list-item markers

### DIFF
--- a/docling_ibm_models/list_item_normalizer/list_marker_processor.py
+++ b/docling_ibm_models/list_item_normalizer/list_marker_processor.py
@@ -44,8 +44,13 @@ class ListItemMarkerProcessor:
             r"[✓✔✗✘]",  # Checkmark bullets
         ]
 
-        # Numbered markers (ordered lists)
+        # Numbered markers (ordered lists). Compound/hierarchical markers are listed
+        # first: they are the more specific patterns, and matching is first-wins.
         self._numbered_patterns = [
+            r"\d+(?:\.\d+)+\.?",  # 1.1  1.2.3  1.1. (dotted decimal outline)
+            r"\d+\.?[a-zA-Z]\.",  # 9a. 3.a.
+            r"\d+\.?[a-zA-Z]\)",  # 9a) 3.a)
+            r"\(\d+\.?[a-zA-Z]\)",  # (9a) (3.a)
             r"\d+\.",  # 1. 2. 3.
             r"\d+\)",  # 1) 2) 3)
             r"\(\d+\)",  # (1) (2) (3)

--- a/tests/test_listitem_marker_model.py
+++ b/tests/test_listitem_marker_model.py
@@ -72,3 +72,85 @@ def test_listitem_marker_model():
     assert processed_doc.texts[2].text=="First item content"
     assert processed_doc.texts[2].marker=="1."
     assert processed_doc.texts[2].enumerated
+
+
+def test_compound_list_item_markers():
+    """Compound/hierarchical markers must be split off like the simple ones.
+
+    Without these patterns the marker stays fused into the text and `marker` is left
+    empty, which makes downstream Markdown serialization prepend a second, position-based
+    number (e.g. "7. 9a. Compute ...").
+    """
+    doc = DoclingDocument(name="Compound markers")
+    group = doc.add_list_group(name="list")
+    for text in [
+        "1. Get the minimal grid dimensions.",
+        "3.a. If all IOU scores are below the threshold, discard.",
+        "9a. Compute the top and bottom boundary.",
+        "9b) Intersect the orphan's bounding box.",
+        "(9c) Compute the left and right boundary.",
+        "1.2.3 Deeply nested item.",
+        "2.1. Dotted item with trailing dot.",
+    ]:
+        doc.add_list_item(text=text, parent=group)
+
+    ListItemMarkerProcessor().process_document(doc)
+
+    items = [item for item in doc.texts if isinstance(item, ListItem)]
+
+    assert [item.marker for item in items] == [
+        "1.",
+        "3.a.",
+        "9a.",
+        "9b)",
+        "(9c)",
+        "1.2.3",
+        "2.1.",
+    ]
+    assert [item.text for item in items] == [
+        "Get the minimal grid dimensions.",
+        "If all IOU scores are below the threshold, discard.",
+        "Compute the top and bottom boundary.",
+        "Intersect the orphan's bounding box.",
+        "Compute the left and right boundary.",
+        "Deeply nested item.",
+        "Dotted item with trailing dot.",
+    ]
+    assert all(item.enumerated for item in items)
+
+
+def test_simple_markers_unchanged_by_compound_patterns():
+    """Compound patterns are matched first, so guard the simple markers against shadowing."""
+    doc = DoclingDocument(name="Simple markers")
+    group = doc.add_list_group(name="list")
+    for text in [
+        "1. One",
+        "12. Twelve",
+        "2) Two",
+        "(3) Three",
+        "[4] Four",
+        "i. Five",
+        "II. Six",
+        "a. Seven",
+        "B) Eight",
+        "• Nine",
+    ]:
+        doc.add_list_item(text=text, parent=group)
+
+    ListItemMarkerProcessor().process_document(doc)
+
+    items = [item for item in doc.texts if isinstance(item, ListItem)]
+
+    assert [item.marker for item in items] == [
+        "1.",
+        "12.",
+        "2)",
+        "(3)",
+        "[4]",
+        "i.",
+        "II.",
+        "a.",
+        "B)",
+        "•",
+    ]
+    assert [item.enumerated for item in items] == [True] * 9 + [False]


### PR DESCRIPTION


This PR is a follow-up to docling-project/docling#3815, where i implementing as Dr @cau-git's suggestion to improve
the existing logic here rather than adding another layer in `docling`. Thank you very much!

## Description

`ListItemMarkerProcessor` currently recognizes only *simple* list markers (`1.`, `1)`, `(1)`,
`[1]`, `i.`, `a.` …). Compound / hierarchical markers are not in `_numbered_patterns`, so items
like `9a. Compute ...`, `3.a. If all ...` or `1.2.3 Deeply nested ...` are never matched: the
marker stays fused into `text` and `marker` is left empty.

This is user-visible downstream. In Docling, a list item with an empty `marker` inside an
otherwise-enumerated list makes the Markdown serializer prepend a *position-based* number of its
own, producing a doubled, wrong marker. On the arXiv Table-Transformer paper
(`tests/data/pdf/groundtruth/2203.01017v2` in `docling`) the algorithm list renders as:

```
3. Use a carefully selected IOU threshold ...
4. 3.a. If all IOU scores ... discard ...        <- doubled + wrong number
4. Find the best-fitting content alignment ...
...
7. 9a. Compute the top and bottom boundary ...   <- doubled + wrong number
8. 9b. Intersect the orphan's bounding box ...
```

This PR adds four patterns to `_numbered_patterns`:

```python
r"\d+(?:\.\d+)+\.?",    # 1.1  1.2.3  1.1. (dotted decimal outline)
r"\d+\.?[a-zA-Z]\.",    # 9a. 3.a.
r"\d+\.?[a-zA-Z]\)",    # 9a) 3.a)
r"\(\d+\.?[a-zA-Z]\)",  # (9a) (3.a)
```

With these, the markers are split off correctly and the same list renders as:

```
3. Use a carefully selected IOU threshold ...
- 3.a. If all IOU scores ... discard ...
4. Find the best-fitting content alignment ...
...
- 9a. Compute the top and bottom boundary ...
- 9b. Intersect the orphan's bounding box ...
```

### Notes on the implementation

- The compound patterns are listed **first** because matching is first-wins and they are the more
  specific ones. They cannot shadow the existing simple patterns (`\d+\.` requires whitespace
  directly after the dot, so `1.1 Foo` and `9a. Foo` never reached it), and there is a regression
  test asserting every existing marker form still parses identically.
- The digit+letter patterns deliberately require a trailing `.` or `)` to keep them conservative.
  The dotted-decimal pattern accepts an optional trailing dot, since `1.1 Introduction` is at
  least as common as `1.1. Introduction`.
- These are matched per item, without list-group context, so — like the existing `\d+\.` pattern —
  a list item whose content genuinely starts with a decimal value (`1.1 million units ...`) will
  have it treated as a marker. Happy to tighten this if you'd prefer a stricter shape.

### Context

This was originally implemented as an extra normalization stage inside `docling`. Fixing it here
instead keeps all list-marker logic in one place. I verified that this change alone produces
exactly the same corrected output as that stage did, so the `docling`-side layer is no longer
needed and that PR can be reduced to a version bump once this is released.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary. 
- [x] Tests have been added, if necessary. 
